### PR TITLE
Make Python 3 compatible

### DIFF
--- a/a7/__init__.py
+++ b/a7/__init__.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
+import six
 import sys
 
 from .validate import validate_py3
@@ -15,7 +16,12 @@ def main():
         sys.stderr.flush()
         sys.exit(1)
 
-    file_path = os.path.realpath(sys.argv[1].decode(sys.getfilesystemencoding()))
+    if isinstance(sys.argv[1], six.text_type):
+        file_path = sys.argv[1]
+    else:
+        file_path = sys.argv[1].decode(sys.getfilesystemencoding())
+
+    file_path = os.path.realpath(file_path)
     if not os.path.exists(file_path):
         sys.stderr.write(u"{} does not exist.\n".format(file_path))
         sys.stderr.flush()

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
 
     packages=['a7'],
-    install_requires=['pylint'],
+    install_requires=['pylint', 'six'],
     include_package_data=True,
 
     entry_points={


### PR DESCRIPTION
Maybe bringing in `six` for this is a little excessive, though it's such an ubiquitous dependency it's probab;y fine. Anyways, the goal of this PR is to allow the linter run on python3 as well.